### PR TITLE
Move project repo links into the heading

### DIFF
--- a/project-status.md
+++ b/project-status.md
@@ -2,100 +2,80 @@
 
 Build, test, and other status indicators for my projects in one place.
 
-## [Autogen][autogen]
+## [Autogen](https://github.com/mbrukman/autogen/)
 
 [![Build Status][autogen-ci-badge]][autogen-ci-url]
 
-[autogen]: https://github.com/mbrukman/autogen/
 [autogen-ci-badge]: https://github.com/mbrukman/autogen/actions/workflows/main.yml/badge.svg
 [autogen-ci-url]: https://github.com/mbrukman/autogen/actions/workflows/main.yml
 
-## [Bloom][bloom]
+## [Bloom](https://github.com/mbrukman/bloom/)
 
 [![Build Status][bloom-ci-badge]][bloom-ci-url]
 
-[bloom]: https://github.com/mbrukman/bloom/
 [bloom-ci-badge]: https://github.com/mbrukman/bloom/actions/workflows/main.yml/badge.svg?branch=main
 [bloom-ci-url]: https://github.com/mbrukman/bloom/actions/workflows/main.yml?query=branch%3Amain
 
-## [Cloud Launcher][cloud-launcher]
+## [Cloud Launcher](https://github.com/mbrukman/cloud-launcher/)
 
 [![Build Status](https://travis-ci.org/mbrukman/cloud-launcher.svg?branch=master)](https://travis-ci.org/mbrukman/cloud-launcher)
 
-[cloud-launcher]: https://github.com/mbrukman/cloud-launcher/
-
-## [C stdlib][c-stdlib]
+## [C stdlib](https://github.com/mbrukman/c-stdlib/)
 
 [![Linux build status][c-stdlib-linux-ci-badge]][c-stdlib-linux-ci-url]
 [![macOS build status][c-stdlib-macos-ci-badge]][c-stdlib-macos-ci-url]
 
-[c-stdlib]: https://github.com/mbrukman/c-stdlib/
 [c-stdlib-linux-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/linux.yml/badge.svg?branch=main
 [c-stdlib-linux-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/linux.yml?query=branch%3Amain
 [c-stdlib-macos-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/macos.yml/badge.svg?branch=main
 [c-stdlib-macos-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/macos.yml?query=branch%3Amain
 
-## [csv2txf]
+## [csv2txf](https://github.com/mbrukman/csv2txf/)
 
 [![Build Status][csv2txf-ci-badge]][csv2txf-ci-url]
 
-[csv2txf]: https://github.com/mbrukman/csv2txf/
 [csv2txf-ci-badge]: https://github.com/mbrukman/csv2txf/actions/workflows/main.yml/badge.svg?query=branch%3Amain
 [csv2txf-ci-url]: https://github.com/mbrukman/csv2txf/actions/workflows/main.yml?query=branch%3Amain
 
-## [Delayed Replay][delayed-replay]
+## [Delayed Replay](https://github.com/mbrukman/delayed-replay/)
 
 No status badges.
 
-[delayed-replay]: https://github.com/mbrukman/delayed-replay/
-
-## [Easyfix][easyfix]
+## [Easyfix](https://github.com/mbrukman/easyfix/)
 
 [![Easyfix build Status][easyfix-ci-badge]][easyfix-ci-url]
 
-[easyfix]: https://github.com/mbrukman/easyfix/
 [easyfix-ci-badge]: https://github.com/mbrukman/easyfix/actions/workflows/main.yml/badge.svg?query=branch%3Amain
 [easyfix-ci-url]: https://github.com/mbrukman/easyfix/actions/workflows/main.yml?query=branch%3Amain
 
-## [Fonts][fonts]
+## [Fonts](https://github.com/mbrukman/fonts/)
 
 No status badges.
 
-[fonts]: https://github.com/mbrukman/fonts/
-
-## [Game Builder][game-builder]
+## [Game Builder](https://github.com/mbrukman/game-builder/)
 
 [![Build Status][game-builder-ci-badge]][game-builder-ci-url]
 
-[game-builder]: https://github.com/mbrukman/game-builder/
 [game-builder-ci-badge]: https://github.com/mbrukman/game-builder/actions/workflows/main.yaml/badge.svg?branch=main
 [game-builder-ci-url]: https://github.com/mbrukman/game-builder/actions/workflows/main.yaml?query=branch%3Amain
 
-## [Kaggle notebooks][kaggle-notebooks]
+## [Kaggle notebooks](https://github.com/mbrukman/kaggle-notebooks/)
 
 No status badges.
 
-[kaggle-notebooks]: https://github.com/mbrukman/kaggle-notebooks/
-
-## [Letters on canvas][letters-on-canvas]
+## [Letters on canvas](https://github.com/mbrukman/letters-on-canvas/)
 
 No status badges.
 
-[letters-on-canvas]: https://github.com/mbrukman/letters-on-canvas/
-
-## [Librarian][librarian]
+## [Librarian](https://github.com/mbrukman/librarian/)
 
 No status badges.
 
-[librarian]: https://github.com/mbrukman/librarian/
-
-## [Math contests][math-contests]
+## [Math contests](https://github.com/mbrukman/math-contests/)
 
 TODO
 
-[math-contests]: https://github.com/mbrukman/math-contests/
-
-## [Notebook][notebook]
+## [Notebook](https://github.com/mbrukman/notebook/)
 
 [![Bazel][notebook-bazel-ci-badge]][notebook-bazel-ci-url]
 [![Node][notebook-node-ci-badge]][notebook-node-ci-url]
@@ -103,7 +83,6 @@ TODO
 [![Go docs][notebook-go-doc-badge]][notebook-go-doc-url]
 [![Go Report Card][notebook-go-report-card-badge]][notebook-go-report-card-url]
 
-[notebook]: https://github.com/mbrukman/notebook/
 [notebook-bazel-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/bazel.yaml/badge.svg?query=branch%3Amain
 [notebook-bazel-ci-url]: https://github.com/mbrukman/notebook/actions/workflows/bazel.yaml?query=branch%3Amain
 [notebook-node-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/node.yaml/badge.svg?query=branch%3Amain
@@ -115,49 +94,41 @@ TODO
 [notebook-go-report-card-badge]: https://goreportcard.com/badge/github.com/mbrukman/notebook
 [notebook-go-report-card-url]: https://goreportcard.com/report/github.com/mbrukman/notebook
 
-## [Polyglot][polyglot]
+## [Polyglot](https://github.com/mbrukman/polyglot/)
 
 No status badges.
 
-[polyglot]: https://github.com/mbrukman/polyglot/
-
-## [Reimplementing ML papers][reimplementing-ml-papers]
+## [Reimplementing ML papers](https://github.com/mbrukman/reimplementing-ml-papers/)
 
 [![Checks & tests status][reimplementing-ml-papers-ci-badge]][reimplementing-ml-papers-ci-url]
 
-[reimplementing-ml-papers]: https://github.com/mbrukman/reimplementing-ml-papers/
 [reimplementing-ml-papers-ci-badge]: https://github.com/mbrukman/reimplementing-ml-papers/actions/workflows/main.yml/badge.svg?query=branch%3Amain
 [reimplementing-ml-papers-ci-url]: https://github.com/mbrukman/reimplementing-ml-papers/actions/workflows/main.yml?query=branch%3Amain
 
-## [Stack Exchange answers][stack-exchange-answers]
+## [Stack Exchange answers](https://github.com/mbrukman/stackexchange-answers/)
 
 No status badges.
 
-[stack-exchange-answers]: https://github.com/mbrukman/stackexchange-answers/
-
-## [Using Preact][using-preact]
+## [Using Preact](https://github.com/mbrukman/using-preactjs/)
 
 [![Build Status][using-preact-ci-badge]][using-preact-ci-url]
 
-[using-preact]: https://github.com/mbrukman/using-preactjs/
 [using-preact-ci-badge]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml/badge.svg
 [using-preact-ci-url]: https://github.com/mbrukman/using-preactjs/actions/workflows/main.yml
 
-## [Using Stimulus][using-stimulus]
+## [Using Stimulus](https://github.com/mbrukman/using-stimulus/)
 
 [![Build Status][using-stimulus-ci-badge]][using-stimulus-ci-url]
 
-[using-stimulus]: https://github.com/mbrukman/using-stimulus/
 [using-stimulus-ci-badge]: https://github.com/mbrukman/using-stimulusjs/actions/workflows/main.yml/badge.svg
 [using-stimulus-ci-url]: https://github.com/mbrukman/using-stimulusjs/actions/workflows/main.yml
 
-## [yaml2json]
+## [yaml2json](https://github.com/mbrukman/yaml2json/)
 
 [![Python build status][yaml2json-python-ci-badge]][yaml2json-python-ci-url]
 [![Go build status][yaml2json-go-ci-badge]][yaml2json-go-ci-url]
 [![Go Report Card][go-report-card-badge]][go-report-card-url]
 
-[yaml2json]: https://github.com/mbrukman/yaml2json/
 [yaml2json-python-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml/badge.svg?query=branch%3Amain
 [yaml2json-python-ci-url]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml?query=branch%3Amain
 [yaml2json-go-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/go.yaml/badge.svg?query=branch%3Amain
@@ -167,9 +138,7 @@ No status badges.
 
 ---
 
-## [JanusGraph][janusgraph]
-
-[janusgraph]: https://github.com/JanusGraph/janusgraph/
+## [JanusGraph](https://github.com/JanusGraph/janusgraph/)
 
 [![Downloads][downloads-shield]][downloads-link]
 [![Docker pulls][docker-pulls-img]][docker-hub-url]
@@ -202,12 +171,11 @@ No status badges.
 
 ---
 
-## [ipycache]
+## [ipycache](https://github.com/rossant/ipycache/)
 
 [![Build Status][ipycache-ci-badge]][ipycache-ci-url]
 [![Latest PyPI version][ipycache-pypi-badge]][ipycache-pypi-url]
 
-[ipycache]: https://github.com/rossant/ipycache/
 [ipycache-ci-badge]: https://github.com/rossant/ipycache/actions/workflows/master.yml/badge.svg
 [ipycache-ci-url]: https://github.com/rossant/ipycache/actions/workflows/master.yml
 [ipycache-pypi-badge]: https://img.shields.io/pypi/v/ipycache.svg
@@ -215,21 +183,19 @@ No status badges.
 
 ---
 
-## [Cmockery][cmockery]
+## [Cmockery](https://github.com/google/cmockery/)
 
 [![Build Status][cmockery-travis-badge]][cmockery-travis-url]
 
-[cmockery]: https://github.com/google/cmockery/
 [cmockery-travis-badge]: https://travis-ci.org/google/cmockery.svg?branch=master
 [cmockery-travis-url]: https://travis-ci.org/google/cmockery
 
-## [Code Review Bot][code-review-bot]
+## [Code Review Bot](https://github.com/google/code-review-bot/)
 
 [![Build Status][code-review-bot-ci-badge]][code-review-bot-ci-url]
 [![Go Report Card][code-review-bot-go-report-card-badge]][code-review-bot-go-report-card-url]
 [![API docs][code-review-bot-go-doc-badge]][code-review-bot-go-doc-url]
 
-[code-review-bot]: https://github.com/google/code-review-bot/
 [code-review-bot-ci-badge]: https://github.com/google/code-review-bot/actions/workflows/main.yml/badge.svg?branch=main
 [code-review-bot-ci-url]: https://github.com/google/code-review-bot/actions/workflows/main.yml?query=branch%3Amain
 [code-review-bot-go-report-card-badge]: https://goreportcard.com/badge/github.com/google/code-review-bot
@@ -237,8 +203,6 @@ No status badges.
 [code-review-bot-go-doc-badge]: https://img.shields.io/badge/godoc-reference-5272B4.svg
 [code-review-bot-go-doc-url]: https://godoc.org/github.com/google/code-review-bot
 
-## [Jsonnet][jsonnet]
+## [Jsonnet](https://github.com/google/jsonnet/)
 
 ![master branch build status badge](https://github.com/google/jsonnet/actions/workflows/build_and_test.yml/badge.svg?event=push&branch=master)
-
-[jsonnet]: https://github.com/google/jsonnet/


### PR DESCRIPTION
Avoid an extra links interspersed with the projects' build status badges.